### PR TITLE
Dynamic invocation frequency

### DIFF
--- a/api-examples/job.json
+++ b/api-examples/job.json
@@ -2,7 +2,7 @@
   "title": "echo",
   "url": "https://postman-echo.com/get?foo1=bar1&foo2=bar2",
   "httpMethod": "GET",
-  "frequency": 20000,
+  "frequency": 20,
   "response": {
     "statusCode": 200
   }

--- a/main.go
+++ b/main.go
@@ -16,8 +16,9 @@ func main() {
 	// inmemory store is default until others are added
 	jobStore := inmemory.New()
 
+	s := &scheduler.Scheduler{}
 	// start periodically firing off job requests
-	go scheduler.Init(jobStore)
+	go s.Init(jobStore)
 
 	// initialize REST API endpoints
 	initRestAPI(jobStore)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -6,24 +6,47 @@ import (
 	"github.com/rknizzle/testlive/datastore"
 	"github.com/rknizzle/testlive/job"
 	"net/http"
+	"reflect"
 	"sync"
 	"time"
 )
 
-// periodically starts a batch of jobs
-// Logic is very simple for now, just send out every request every 10 seconds.
-// In a future update each job will have a set frequency and the scheduler will
-// handle when each request should be sent
-func Init(jobStore datastore.Datastore) {
-	batchJobs(jobStore)
-	ticker := time.NewTicker(10 * time.Second)
+// Scheduler holds the collection of jobs and when to execute them
+type Scheduler struct {
+	jobs []*jobTimer
+}
 
+// start scheduling counter
+func (s *Scheduler) Init(jobstore datastore.Datastore) {
+	// load in all the jobs and
+	var collection []jobTimer
+	jobs := jobstore.GetAll()
+	for _, j := range jobs {
+		jt := &jobTimer{0, j}
+		collection = append(collection, *jt)
+	}
+
+	// start the counter
+	start := time.Now()
+	ticker := time.NewTicker(1 * time.Second)
 	for {
 		select {
 		case <-ticker.C:
-			batchJobs(jobStore)
+			// for each tick of the ticker, make sure the jobs are synced up
+			// with the datastore and check if any jobs should be executed
+			count := int64(time.Since(start)) / 1e9
+			c := int(count)
+			go s.syncDatastore(jobstore, c)
+			go s.startReadyJobs(jobstore, c)
 		}
 	}
+}
+
+// jobTimer contains a job as well as the count
+// in which to trigger the execution of the job
+type jobTimer struct {
+	count int
+	job   *job.Job
 }
 
 // used to match up the job with the result using the id
@@ -33,18 +56,18 @@ type result struct {
 	err error
 }
 
-// sends out a request for each job
-func batchJobs(jobStore datastore.Datastore) {
+// Go through all jobTimers to find any jobs ready to be ran
+func (s *Scheduler) startReadyJobs(jobstore datastore.Datastore, count int) {
 	ch := make(chan *result)
-
 	var wg sync.WaitGroup
-	jobs := jobStore.GetAll()
-	// loop through all jobs
-	for _, job := range jobs {
-		wg.Add(1)
-		go execute(job, ch, &wg)
-	}
+	for _, i := range s.jobs {
+		if i.count <= count {
+			i.count += i.job.Frequency
+			wg.Add(1)
+			go execute(i.job, ch, &wg)
+		}
 
+	}
 	// close the channel in the background
 	go func() {
 		wg.Wait()
@@ -54,11 +77,48 @@ func batchJobs(jobStore datastore.Datastore) {
 	// read from channel as they come in until its closed
 	// the channel will close when all requests receive a response
 	for res := range ch {
-		job, err := jobStore.Get(res.id)
+		job, err := jobstore.Get(res.id)
 		if err != nil {
 			panic(err)
 		}
-		verifyResponse(job, res)
+		// check if the response from the request matches the expected response
+		verifyResponse(jobstore, job, res)
+	}
+}
+
+// sync up the jobs in the datastore with the job data used by the scheduler
+func (s *Scheduler) syncDatastore(jobstore datastore.Datastore, count int) {
+	// add any new jobs
+	// and update jobs that have been changed
+	jobs := jobstore.GetAll()
+
+	var match bool
+
+	// loop through the jobs in the datastore
+	for _, djob := range jobs {
+		match = false
+		// and loop through the jobs that the scheduler is currently working with
+		for _, sjob := range s.jobs {
+			// check if the job from the store already exists in the schedulers collection
+			if djob.ID == sjob.job.ID {
+				match = true
+				// if the ids are the same but the objects are not equal anymore then reset the count
+				// so the updated job will be executed immediately
+				if !reflect.DeepEqual(djob, sjob.job) {
+					sjob.count = count + 3
+				}
+				// set the job to the most recent version in the datastore
+				sjob.job = djob
+			}
+		}
+		// if the job does not already belong in the schedulers collection then the
+		// job must be new and should be added to the collection
+		if match != true {
+			// add the datastore job to the schedulers collection
+			// and make sure it is executed shortly after being added
+			newTimer := &jobTimer{count + 3, djob}
+			s.jobs = append(s.jobs, newTimer)
+		}
 	}
 }
 
@@ -84,11 +144,13 @@ func execute(job *job.Job, ch chan<- *result, wg *sync.WaitGroup) {
 }
 
 // check that the status code of the http request matches the expected code
-func verifyResponse(job *job.Job, r *result) bool {
+func verifyResponse(jobstore datastore.Datastore, job *job.Job, r *result) bool {
 	if r.res.StatusCode == job.Response.StatusCode {
 		job.Status = "passing"
+		jobstore.Update(job.ID, job)
 		return true
 	}
 	job.Status = "failing"
+	jobstore.Update(job.ID, job)
 	return false
 }

--- a/templates/jobForm.html
+++ b/templates/jobForm.html
@@ -9,6 +9,8 @@
     <input id="url" type="text" url="url" value={{.URL}}><br>
     <p>Expected Status Code</p>
     <input id="statusCode" type="text" statusCode="statusCode" value={{.Response.StatusCode}}><br>
+    <p>Frequency in seconds</p>
+    <input id="frequency" type="text" frequency="frequency" value={{.Frequency}}><br>
     <button id="submit">SUBMIT</button>
     <script>
       // Submit button execution
@@ -18,6 +20,7 @@
         let title = document.getElementById('title').value
         let url = document.getElementById('url').value
         let statusCode = document.getElementById('statusCode').value
+        let frequency = document.getElementById('frequency').value
 
         let payload = {
           id,
@@ -26,6 +29,7 @@
           response: {
             statusCode: parseInt(statusCode),
           },
+          frequency: parseInt(frequency),
         }
         if (id == "") {
           createJob(payload)


### PR DESCRIPTION
Updated the scheduler to allow each job to have an individual frequency instead of sending all calls out in a batch.
It also makes jobs that get updated or added immediately executed instead of having to wait for the batch call to go out